### PR TITLE
Create a No-Op Requester

### DIFF
--- a/requester/noop.go
+++ b/requester/noop.go
@@ -1,0 +1,35 @@
+package requester
+
+import (
+	"sync"
+
+	"github.com/tylertreat/bench"
+)
+
+type NOOPRequesterFactory struct {
+}
+
+var instance bench.Requester
+var once sync.Once
+
+func (n *NOOPRequesterFactory) GetRequester(num uint64) bench.Requester {
+	once.Do(func() {
+		instance = &noopRequester{}
+	})
+	return instance
+}
+
+type noopRequester struct {
+}
+
+func (n *noopRequester) Setup() error {
+	return nil
+}
+
+func (n *noopRequester) Request() error {
+	return nil
+}
+
+func (n *noopRequester) Teardown() error {
+	return nil
+}


### PR DESCRIPTION
Purpose of this impl is to check the raw performance of the load generator to exclude that slow results are due to load generator being overloaded.