### PR TITLE
Readme example matches source example

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,6 +33,6 @@ func main() {
 	}
 
 	fmt.Println(summary)
-	summary.GenerateLatencyDistribution(bench.Logarithmic, "redis.txt")
+	summary.GenerateLatencyDistribution(nil, "redis.txt")
 }
 ```


### PR DESCRIPTION
`bench.Logarithmic` is no longer a valid parameter to the `GenerateLatencyDistribution`.